### PR TITLE
Shyam pycdt

### DIFF
--- a/pymatgen/analysis/defects/corrections.py
+++ b/pymatgen/analysis/defects/corrections.py
@@ -17,8 +17,8 @@ norm = np.linalg.norm
 from scipy import stats  #for statistical uncertainties of pot alignment
 from monty.json import MSONable
 from pymatgen.util.coord import pbc_shortest_vectors
-from core import DefectCorrection
-from utils import ang_to_bohr, hart_to_ev, eV_to_k, generate_reciprocal_vectors_squared, QModel, genrecip
+from pymatgen.analysis.defects.core import DefectCorrection
+from pymatgen.analysis.defects.utils import ang_to_bohr, hart_to_ev, eV_to_k, generate_reciprocal_vectors_squared, QModel, genrecip
 
 import matplotlib
 matplotlib.use('Agg')
@@ -61,6 +61,8 @@ class FreysoldtCorrection(DefectCorrection):
         else:
             self.dielectric = float(np.mean(np.diag(dielectric_const)))
 
+        self.metadata = {'pot_plot_data': {}, 'pot_corr_uncertainty_md': {}}
+
     def get_correction(self, entry):
         """
         Gets the Freysoldt correction for a defect entry
@@ -83,7 +85,6 @@ class FreysoldtCorrection(DefectCorrection):
             madetol=self.madelung_energy_tolerance)
 
         pot_corr_tracker = []
-        self.metadata = {'pot_plot_data': {}, 'pot_corr_uncertainty_md': {}}
 
         for x, pureavg, defavg, axis in zip(list_axis_grid,
                                             list_bulk_plnr_avg_esp,
@@ -528,6 +529,8 @@ class KumagaiCorrection(DefectCorrection):
                                           self.metadata['g_sum'], dim, self.metadata['gamma'],
                                           self.madelung_energy_tolerance)
 
+        entry.parameters["kumagai_meta"] = dict(self.metadata)
+
         return {"kumagai_electrostatic": es_corr,
                 "kumagai_potential_alignment": pot_corr}
 
@@ -832,6 +835,8 @@ class BandFillingCorrection(DefectCorrection):
         cbm = entry.parameters["cbm"]
 
         bf_corr = self.perform_bandfill_corr( eigenvalues, kpoint_weights, potalign, vbm, cbm)
+
+        entry.parameters["bandfilling_meta"] = dict(self.metadata)
 
         return {'bandfilling': bf_corr}
 

--- a/pymatgen/analysis/defects/corrections.py
+++ b/pymatgen/analysis/defects/corrections.py
@@ -41,10 +41,7 @@ class FreysoldtCorrection(DefectCorrection):
 
         defect_planar_averages
 
-
-        axis: The axis to calculate on, if none, averages over all three.  #TODO: Actually implement this
-    axis_grid, pureavg, defavg, lattice, dielectricconst, q, defect_position, axis,
-                          q_model=QModel(), madetol=0.0001, title=None, widthsample=1.0
+        axis: The axes to calculate on, if none given, averages over all three.
 
     """
 
@@ -61,6 +58,8 @@ class FreysoldtCorrection(DefectCorrection):
         else:
             self.dielectric = float(np.mean(np.diag(dielectric_const)))
 
+        self.axis = axis
+
         self.metadata = {'pot_plot_data': {}, 'pot_corr_uncertainty_md': {}}
 
     def get_correction(self, entry):
@@ -71,7 +70,11 @@ class FreysoldtCorrection(DefectCorrection):
         list_axis_grid = np.array(entry.parameters["axis_grid"])
         list_bulk_plnr_avg_esp = np.array(entry.parameters["bulk_planar_averages"])
         list_defect_plnr_avg_esp = np.array(entry.parameters["defect_planar_averages"])
-        list_axes = range(len(list_axis_grid))
+
+        if not self.axis:
+            list_axes = range(len(list_axis_grid))
+        else:
+            list_axes = self.axis
 
         lattice = entry.defect.bulk_structure.lattice
         q = entry.defect.charge
@@ -112,7 +115,6 @@ class FreysoldtCorrection(DefectCorrection):
 
         return {"freysoldt_electrostatic": es_corr,
                 "freysoldt_potential_alignment": pot_corr}
-
 
     def perform_es_corr(self, lattice, dielectric, q, energy_cutoff=520, q_model=QModel(), madetol=0.0001):
         """
@@ -273,7 +275,6 @@ class FreysoldtCorrection(DefectCorrection):
         logger.info('Potentital alignment energy correction (-q*delta V):  %f (eV)', -q * C)
         self.pot_corr = -q * C
 
-        #TODO: Where ot put this metadata?
         #log plotting data:
         self.metadata['pot_plot_data'][axis] = {'Vr':v_R, 'x': axis_grid, 'dft_diff': defavg - pureavg,
                                                     'final_shift':final_shift, 'check': [mid - checkdis, mid + checkdis + 1]}
@@ -752,6 +753,7 @@ class KumagaiCorrection(DefectCorrection):
         return pot_corr
 
 
+# TODO: Make this a part of above
 def kumagai_plotter(r, Vqb, Vpc, eltnames, samplerad=None, title = None, saved=False):
     """
     atomic site  electrostatic potential plotter for Kumagai

--- a/pymatgen/analysis/defects/corrections.py
+++ b/pymatgen/analysis/defects/corrections.py
@@ -108,6 +108,7 @@ class FreysoldtCorrection(DefectCorrection):
         pot_corr = np.mean(pot_corr_tracker)
 
         entry.parameters["freysoldt_meta"] = dict(self.metadata)
+        entry.parameters['potalign'] = pot_corr / (-q)
 
         return {"freysoldt_electrostatic": es_corr,
                 "freysoldt_potential_alignment": pot_corr}
@@ -530,6 +531,7 @@ class KumagaiCorrection(DefectCorrection):
                                           self.madelung_energy_tolerance)
 
         entry.parameters["kumagai_meta"] = dict(self.metadata)
+        entry.parameters['potalign'] = pot_corr / (-q)
 
         return {"kumagai_electrostatic": es_corr,
                 "kumagai_potential_alignment": pot_corr}

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -87,7 +87,7 @@ class VacancyGenerator(DefectGenerator):
                 site_index = self.structure.get_sites_in_sphere(vac_site[0].coords, 0.1, include_index=True)[0][2]
                 charge = -1 * self.struct_valences[site_index]
 
-            return Vacancy(self.structure, vac_site[0], multiplicity=len(vac_site), charge=charge)
+            return Vacancy(self.structure, vac_site[0], charge=charge)
         else:
             raise StopIteration
 
@@ -164,7 +164,7 @@ class VoronoiInterstitialGenerator(DefectGenerator):
             struct_to_trim.append( self.element, poss_inter.frac_coords, coords_are_cartesian=False)
 
         symmetry_finder = SpacegroupAnalyzer(struct_to_trim, symprec=1e-1)
-        equiv_sites_list = symmetry_finder.get_symmetrized_struct().equivalent_sites
+        equiv_sites_list = symmetry_finder.get_symmetrized_structure().equivalent_sites
 
         self.equiv_site_seq = []
         for poss_site_list in equiv_sites_list:

--- a/pymatgen/analysis/defects/tests/test_corrections.py
+++ b/pymatgen/analysis/defects/tests/test_corrections.py
@@ -207,7 +207,8 @@ class DefectsCorrectionsTest(PymatgenTest):
         bf_corr = bfc.perform_bandfill_corr( eigenvalues, kptweights, potalign, vbm, cbm)
         self.assertAlmostEqual(bfc.metadata['num_hole_vbm'], 0.)
         self.assertAlmostEqual(bf_corr, 0.)
-        occu = [[1.6204, 0.16666668], [1.6346500000000002, 0.16666668], [1.557, 0.16666668], [1.6498000000000002, 0.08333334]]
+        occu = [[1.5569999999999999, 0.16666668000000001], [1.6346500000000002, 0.16666668000000001],
+                [1.6498000000000002, 0.083333340000000006], [1.6204000000000001, 0.16666668000000001]]
         self.assertEqual(bfc.metadata['occupied_def_levels'], occu)
         self.assertEqual(bfc.metadata['total_occupation_defect_levels'], 0.58333338)
         self.assertFalse(bfc.metadata['unoccupied_def_levels'])
@@ -220,8 +221,8 @@ class DefectsCorrectionsTest(PymatgenTest):
         self.assertAlmostEqual(bfc.metadata['num_hole_vbm'], 0.)
         self.assertAlmostEqual(bf_corr, 0.)
         self.assertFalse(bfc.metadata['occupied_def_levels'])
-        unoccu = [4.0589, 4.07565, 4.063840000000001, 4.00525, 4.013800000000001,
-                  4.0324, 4.04355, 3.9906, 3.9951499999999998]
+        unoccu = [4.0052500000000002, 4.0435499999999998, 3.9951499999999998, 3.9906000000000001,
+                  4.0589000000000004, 4.0638400000000008, 4.0138000000000007, 4.0756500000000004, 4.0324]
         self.assertEqual(bfc.metadata['unoccupied_def_levels'], unoccu)
 
 

--- a/pymatgen/analysis/defects/tests/test_corrections.py
+++ b/pymatgen/analysis/defects/tests/test_corrections.py
@@ -46,7 +46,7 @@ class DefectsCorrectionsTest(PymatgenTest):
         self.assertAlmostEqual(val['freysoldt_electrostatic'], 0.976412)
         self.assertAlmostEqual(val['freysoldt_potential_alignment'], 4.4700574)
 
-        #test the freysoldt plotter
+        #test the freysoldt plotter and that plot metadata exists
         pltsaver = []
         for ax in range(3):
             x = fc.metadata['pot_plot_data'][ax]['x']
@@ -58,6 +58,45 @@ class DefectsCorrectionsTest(PymatgenTest):
             if fp: #if plot exists then append it...
                 pltsaver.append(fp)
         self.assertEqual(len(pltsaver), 3)
+
+        #check that uncertainty metadata exists
+        for ax in range(3):
+            self.assertEqual(set(fc.metadata['pot_corr_uncertainty_md'][ax].keys()), set(['potcorr', 'stats']))
+
+        #test a specified axis from entry
+        fc = FreysoldtCorrection(15, axis = [1])
+        val = fc.get_correction(de)
+        self.assertAlmostEqual(val['freysoldt_potential_alignment'], 5.2869010593283132)
+
+        #test a different charge
+        #   for electrostatic correction
+        es_corr = fc.perform_es_corr(struc.lattice, 15., 2)
+        self.assertEqual(es_corr, 0.43396099999999999)
+        #   for potential alignment method
+        pot_corr = fc.perform_pot_corr( axisdata[0], bldata[0], dldata[0], struc.lattice, 15., 2, vac.site.coords, 0)
+        self.assertEqual(pot_corr, -2.1375685936497768)
+
+        #test an input anisotropic dielectric constant
+        fc = FreysoldtCorrection([[1.,2.,3.],[0.,3.,5.],[4., 10., 8.]])
+        self.assertEqual( fc.dielectric, 4.)
+        val = fc.get_correction(de)
+        self.assertAlmostEqual(val['freysoldt_electrostatic'], 3.6615440000000001)
+        self.assertAlmostEqual(val['freysoldt_potential_alignment'], 3.3605255195745087)
+
+        #test potalign being added to defect entry
+        self.assertEqual( de.parameters['potalign'], 1.1201751731915028)
+
+        #test that metadata entries exist in defect entry
+        self.assertTrue( 'freysoldt_meta' in de.parameters.keys())
+        self.assertEqual( set(de.parameters['freysoldt_meta'].keys()), set(['pot_plot_data', 'pot_corr_uncertainty_md']))
+
+        #test a charge of zero
+        vac = Vacancy(struc, struc.sites[0], charge=0)
+        de = DefectEntry( vac, 0., corrections={}, parameters=params, entry_id=None)
+        val = fc.get_correction(de)
+        self.assertEqual(val['freysoldt_electrostatic'], 0.)
+        self.assertEqual(val['freysoldt_potential_alignment'], 0.)
+
 
     def test_kumagai(self):
         struc = PymatgenTest.get_structure("VO2")
@@ -102,18 +141,17 @@ class DefectsCorrectionsTest(PymatgenTest):
 
         #test entry full correction method
         de = DefectEntry( vac, 0., corrections={}, parameters=params, entry_id=None)
-        KC = KumagaiCorrection( epsilon, gamma=gamma, g_sum=g_sum)
-        val = KC.get_correction(de)
+        kc = KumagaiCorrection( epsilon, gamma=gamma, g_sum=g_sum)
+        val = kc.get_correction(de)
         self.assertAlmostEqual(val['kumagai_electrostatic'], 0.976413164047)
         self.assertAlmostEqual(val['kumagai_potential_alignment'], 0.2938097394999)
 
         #test wigner-seitz sampling radius method
-        self.assertAlmostEqual(KC.metadata['sampling_radius'], 4.5531438299999)
-
+        self.assertAlmostEqual(kc.metadata['sampling_radius'], 4.5531438299999)
 
         #test the kumagai plotter
         eltnames = []
-        for bsind in KC.metadata['pot_corr_uncertainty_md']['AllData'].keys():
+        for bsind in kc.metadata['pot_plot_data'].keys():
             eltnames.append( vac.bulk_structure.sites[bsind].specie.symbol)
 
         eltnames = list(set(eltnames))
@@ -123,7 +161,7 @@ class DefectsCorrectionsTest(PymatgenTest):
         Vqbset = [[] for tmp in range(len(eltnames))]
         Vpcset = [[] for tmp in range(len(eltnames))]
 
-        for bsind, vals in KC.metadata['pot_corr_uncertainty_md']['AllData'].items():
+        for bsind, vals in kc.metadata['pot_plot_data'].items():
             elttype = vac.bulk_structure.sites[bsind].specie.symbol
             eltind = eltkey[elttype]
             rset[eltind].append(vals['dist_to_defect'])
@@ -132,6 +170,58 @@ class DefectsCorrectionsTest(PymatgenTest):
 
         kp = kumagai_plotter(rset, Vqbset, Vpcset, eltnames, samplerad=4.5, title = 'test', saved=False)
         self.assertTrue( kp)
+
+        #check that uncertainty metadata exists
+        self.assertEqual(set(kc.metadata['pot_corr_uncertainty_md'].keys()), set(['number_sampled', 'stats']))
+        self.assertEqual(kc.metadata['pot_corr_uncertainty_md']['number_sampled'], 125)
+
+        #test a different sampling radius
+        new_sampling_radius = 8.
+        pot_corr = kc.perform_pot_corr( vac.bulk_structure, defect_structure, defect_position, site_list,
+                                        new_sampling_radius, -3, g_sum, dim, gamma,  kc.madelung_energy_tolerance)
+        self.assertEqual(pot_corr, 0.021267067525360898)
+        self.assertEqual(kc.metadata['pot_corr_uncertainty_md']['number_sampled'], 21)
+        #   also test sampling radius from entry
+        kc = KumagaiCorrection( epsilon, sampling_radius=new_sampling_radius, gamma=gamma, g_sum=g_sum)
+        val = kc.get_correction(de)
+        self.assertAlmostEqual(val['kumagai_potential_alignment'], 0.021267067525360898)
+
+        #test a different charge
+        #   for electrostatic correction
+        es_corr = kc.perform_es_corr( vac.bulk_structure, 2, g_sum, gamma, kc.madelung_energy_tolerance)
+        self.assertEqual(es_corr, 0.43396140624317336)
+        #   for potential alignment method
+        pot_corr = kc.perform_pot_corr( vac.bulk_structure, defect_structure, defect_position, site_list,
+                                        sampling_radius, 2, g_sum, dim, gamma,  kc.madelung_energy_tolerance)
+        self.assertEqual(pot_corr, -0.53065138774428844)
+
+        #test an input anisotropic dielectric constant
+        aniso_dielectric = np.array([[15.,0,3.],[0,15.,0.],[0,0,10.]])
+        aniso_gamma = 2.0068661368556668
+        aniso_g_sum = generate_g_sum( vac.bulk_structure, aniso_dielectric, dim, aniso_gamma)
+        kc = KumagaiCorrection(aniso_dielectric, gamma=aniso_gamma, g_sum=aniso_g_sum)
+        for u,v in zip(kc.dielectric.flatten(), aniso_dielectric.flatten()):
+            self.assertEqual(u, v)
+        es_corr = kc.perform_es_corr( vac.bulk_structure, -3, aniso_g_sum, aniso_gamma, kc.madelung_energy_tolerance)
+        self.assertEqual(es_corr, 1.027001049757768)
+        pot_corr = kc.perform_pot_corr( vac.bulk_structure, defect_structure, defect_position,
+                                        site_list, sampling_radius, -3, aniso_g_sum, dim, aniso_gamma,  kc.madelung_energy_tolerance)
+        self.assertEqual(pot_corr, 0.2457398743896354)
+
+        #test potalign being added to defect entry
+        self.assertEqual( de.parameters['potalign'],0.0070890225084536329)
+
+        #test that metadata entries exist in defect entry
+        self.assertTrue( 'kumagai_meta' in de.parameters.keys())
+        self.assertEqual( set(de.parameters['kumagai_meta'].keys()), set(['pot_plot_data', 'sampling_radius', 'gamma','pot_corr_uncertainty_md']))
+
+        #test a charge of zero
+        vac = Vacancy(struc, struc.sites[0], charge=0)
+        de = DefectEntry( vac, 0., corrections={}, parameters=params, entry_id=None)
+        val = kc.get_correction(de)
+        self.assertEqual(val['kumagai_electrostatic'], 0.)
+        self.assertEqual(val['kumagai_potential_alignment'], 0.)
+
 
     def test_bandfilling(self):
         v = Vasprun(os.path.join(test_dir, 'vasprun.xml'))
@@ -164,7 +254,6 @@ class DefectsCorrectionsTest(PymatgenTest):
         corr = bfc.get_correction( de)
         self.assertAlmostEqual(corr['bandfilling'], 0.)
 
-
         #modify the eigenvalue list to have free holes
         hole_eigenvalues = {}
         for spinkey, spinset in eigenvalues.items():
@@ -181,7 +270,6 @@ class DefectsCorrectionsTest(PymatgenTest):
         self.assertAlmostEqual(hole_bf_corr, -0.82276673248)
         self.assertAlmostEqual(bfc.metadata['num_hole_vbm'], 1.6250001299)
         self.assertFalse(bfc.metadata['num_elec_cbm'])
-
 
         #modify the eigenvalue list to have free electrons
         elec_eigenvalues = {}
@@ -200,7 +288,6 @@ class DefectsCorrectionsTest(PymatgenTest):
         self.assertAlmostEqual(bfc.metadata['num_elec_cbm'], 1.708333469999)
         self.assertFalse(bfc.metadata['num_hole_vbm'])
 
-
         #modify the potalignment and introduce new occupied defect levels from vbm states
         potalign = 0.1
 
@@ -212,19 +299,6 @@ class DefectsCorrectionsTest(PymatgenTest):
         self.assertEqual(bfc.metadata['occupied_def_levels'], occu)
         self.assertEqual(bfc.metadata['total_occupation_defect_levels'], 0.58333338)
         self.assertFalse(bfc.metadata['unoccupied_def_levels'])
-
-
-        #modify the potalignment and introduce new unoccupied defect levels from cbm states
-        potalign = -0.1
-
-        bf_corr = bfc.perform_bandfill_corr( eigenvalues, kptweights, potalign, vbm, cbm)
-        self.assertAlmostEqual(bfc.metadata['num_hole_vbm'], 0.)
-        self.assertAlmostEqual(bf_corr, 0.)
-        self.assertFalse(bfc.metadata['occupied_def_levels'])
-        unoccu = [4.0052500000000002, 4.0435499999999998, 3.9951499999999998, 3.9906000000000001,
-                  4.0589000000000004, 4.0638400000000008, 4.0138000000000007, 4.0756500000000004, 4.0324]
-        self.assertEqual(bfc.metadata['unoccupied_def_levels'], unoccu)
-
 
 
 

--- a/pymatgen/analysis/defects/tests/test_generators.py
+++ b/pymatgen/analysis/defects/tests/test_generators.py
@@ -7,7 +7,6 @@ from __future__ import unicode_literals
 import unittest
 
 from pymatgen.util.testing import PymatgenTest
-from pymatgen.core.sites import Site
 from pymatgen.analysis.defects.generators import VacancyGenerator, InterstitialGenerator, VoronoiInterstitialGenerator
 
 class VacancyGeneratorTest(PymatgenTest):
@@ -18,7 +17,8 @@ class VacancyGeneratorTest(PymatgenTest):
         vacs = list(vac_gen)
         self.assertEqual(len(vacs), 2)
 
-        multiplicities = {str(v.defect_site.specie): v.multiplicity for v in vacs}
+
+        multiplicities = {str(v.site.specie): v.multiplicity for v in vacs}
         self.assertEqual(multiplicities, {"O": 4, "V": 2})
 
     def test_vacancy_gen_charges(self):
@@ -26,9 +26,9 @@ class VacancyGeneratorTest(PymatgenTest):
         struc = PymatgenTest.get_structure("VO2")
         vac_gen = VacancyGenerator(struc, include_bv_charge=True)
         for vac in vac_gen:
-            if str(vac.defect_site.specie) == "V":
+            if str(vac.site.specie) == "V":
                 self.assertEqual(vac.charge, -4)
-            if str(vac.defect_site.specie) == "O":
+            if str(vac.site.specie) == "O":
                 self.assertEqual(vac.charge, 2)
 
 
@@ -41,18 +41,36 @@ class InterstitialGeneratorTest(PymatgenTest):
         self.assertEqual(len(ints), 2)
 
         multiplicities = [i.multiplicity for i in ints]
-        self.assertEqual(multiplicities, [1, 1])
+        self.assertEqual(multiplicities, [4, 2])
 
-        self.assertEqual(str(ints[0].specie), "Li")
-        self.assertEqual(str(ints[1].specie), "Li")
+        self.assertEqual(str(ints[0].site.specie), "Li")
+        self.assertEqual(str(ints[1].site.specie), "Li")
 
-        self.assertArrayAlmostEqual(ints[0].defect_site.coords, (0.9106, 0.3078, 0.3078))
-        self.assertArrayAlmostEqual(ints[1].defect_site.coords, (1.5177, 0.7183, 0.7183))
+        self.assertArrayAlmostEqual(ints[0].site.coords, (0.9106, 0.3078, 0.3078))
+        self.assertArrayAlmostEqual(ints[1].site.coords, (1.5177, 0.7183, 0.7183))
 
 
 class VoronoiInterstitialGeneratorTest(PymatgenTest):
     def test_int_gen(self):
-        pass
+        struc = PymatgenTest.get_structure("VO2")
+        int_gen = VoronoiInterstitialGenerator(struc, "Li")
+
+        ints = list(int_gen)
+        self.assertEqual(len(ints), 4)
+
+        multiplicities = [i.multiplicity for i in ints]
+        self.assertEqual(multiplicities, [8, 8, 4, 4])
+
+        self.assertEqual(str(ints[0].site.specie), "Li")
+        self.assertEqual(str(ints[1].site.specie), "Li")
+        self.assertEqual(str(ints[2].site.specie), "Li")
+        self.assertEqual(str(ints[3].site.specie), "Li")
+
+        self.assertArrayAlmostEqual(ints[0].site.coords, (1.5177146, 2.6784354, 3.9481299))
+        self.assertArrayAlmostEqual(ints[1].site.coords, (1.7357692, 3.8392513, 3.8392513))
+        self.assertArrayAlmostEqual(ints[2].site.coords, (1.5177146, 3.7168193, 3.7168193))
+        self.assertArrayAlmostEqual(ints[3].site.coords, (2.2765713, 2.2575138, 4.5150233))
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- make a unit test for Voronoi site finder 
- get freysoldt, kumagai and bandfilling to save metadata to entry.parameters['kumagai']  ['bandfilling'] etc.
- get freysoldt or kumagai to set the potalign parameter to be used by the BandFillingCorrection
- add functionality for axis to be actually specified for use in freysoldt code